### PR TITLE
Created values-es folder in res folder

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="app_name">Vigilancia Nutricional</string>
+    <string name="hello_world">Hola mundo!</string>
+    <string name="action_settings">Ajustes</string>
+
+</resources>


### PR DESCRIPTION
The values-es folder only contains a strings.xml folder which is needed
to allow for language support in spanish. Every string in english that
is added to the strings.xml file in the normal values folder must also
be added to the strings.xml file in the values-es folder in spanish